### PR TITLE
Jelly Jamboree

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,10 @@ custom_components/jellyfin_status/
 | Field | Description | Example Output |
 | :--- | :--- | :--- |
 | `{user}` | Jellyfin username | `homer` |
+| `{device}` | The hardware name | `Chrome`, `Roku` |
+| `{client}` | The application used | `Jellyfin Web`, `Infuse` |
 | `{title}` | Media title (Movie name, Episode title, or Song) | `Abominable` |
+| `{audio}` | Audio Codec and Channels | `DTS 5.1`, `FLAC Stereo` |
 | `{quality}` | Resolution and Dynamic Range (Video only) | `4K HDR`, `1080p` |
 | `{series}` | TV Series name | `The Bear` |
 | `{season}` | Season number | `2` |


### PR DESCRIPTION
## 🚀 v2026.01.15 - Jelly Jamboree

This update focuses on deep audio telemetry and a complete overhaul of how the integration tracks concurrent sessions. Whether you are multi-tasking across devices or running a high-fidelity home theater, your server status just got much more detailed.

### 🎙️ High-Fidelity Audio Tracking
Unlocked the audio stream data. You can now track exactly what codec and channel configuration is being served by the server.
- **New `{audio}` tag:** Use this in your custom playback format string (e.g., `[{audio}]`).
- **Dynamic Labels:** Displays full codec and channel info (e.g., `DTS 5.1`, `FLAC Stereo`, `AAC Mono`).
- **Raw Data:** Audio details are now included in the `playback_states` attribute for use in advanced Jinja2 templates.

### 👯 Multi-Session Intelligence
The integration no longer "collides" when the same user plays multiple items simultaneously on different devices.
- **Unique Session Tracking:** The internal data structure now uses Jellyfin `Session IDs` as the primary key. This allows the sensor to report on multiple simultaneous streams from the same account without data being overwritten.
- **Identity Awareness:** Every session now includes its own `device` and `client` attributes (e.g., "Chrome", "Sony TV", "Shield Android TV") for easier identification in your dashboards.

